### PR TITLE
General Service Changes

### DIFF
--- a/Services/include/general.h
+++ b/Services/include/general.h
@@ -27,8 +27,14 @@ SAT_returnState start_general_service(void);
 
 typedef enum {
     REBOOT = 0,
-    GET_UHF_WATCHDOG_TIMEOUT = 1,
-    SET_UHF_WATCHDOG_TIMEOUT = 2,
+    DEPLOY_DEPLOYABLES = 1,
+    GET_SWITCH_STATUS = 2,
+    GET_UHF_WATCHDOG_TIMEOUT = 3,
+    SET_UHF_WATCHDOG_TIMEOUT = 4,
+    GET_SBAND_WATCHDOG_TIMEOUT = 5,
+    SET_SBAND_WATCHDOG_TIMEOUT = 6,
+    GET_CHARON_WATCHDOG_TIMEOUT = 7,
+    SET_CHARON_WATCHDOG_TIMEOUT = 8,
 } General_Subtype;
 
 typedef enum { bootloader = 'B', golden = 'G', application = 'A' } reboot_mode;


### PR DESCRIPTION
Add switch status, deploy, and subsystem watchdog timer commands to general service, and improve consistency w other services

## [Clickup Task](app.clickup.com)(if applicable)
N/A

## Description of changes
Changes to improve consistency with other services. Adds commands to get the status of all deployment switches, burn a specific burnwire and return the current, plus the ability to fetch and configure the periodicity of the subsystem watchdog timers for the SBAND and Charon.
Changes made jointly by Thomas and Grace

## Testing done
Tested on flatsat using ground station

## Merge checklist
- [x] Docker image or CCS Project builds with the changes
- [x] Docker image or CCS Project runs with the changes
- [x] Can send commands from a mocked ground station/relevant changes tested
- [ ] Changes have been reviewed
